### PR TITLE
Removed getting of go vet from test script

### DIFF
--- a/elasticsearch/elasticsearch_test.go
+++ b/elasticsearch/elasticsearch_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 /*
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
@@ -15,9 +17,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//
-// +build unit
 
 package elasticsearch
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,6 @@ if [[ $TEST_SUITE == "unit" ]]; then
 	go get github.com/axw/gocov/gocov
 	go get github.com/mattn/goveralls
 	go get -u github.com/golang/lint/golint
-	go get golang.org/x/tools/cmd/vet
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/smartystreets/goconvey/convey
 	go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Removed go vet import because of this [commit](https://github.com/golang/tools/commit/adaaa074861b0d254acf51dec74daf7c2ba20e90), without updating test.sh it is not possible to successfully execute tests.