### PR TITLE
SDI-1564 ES does not load without Name for dynamic element

### DIFF
--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -158,10 +158,13 @@ func getMetrics(pct plugin.ConfigType) ([]plugin.MetricType, error) {
 
 	mts := []plugin.MetricType{}
 	for _, n := range mMap {
-		for ns, _ := range n {
+		for ns := range n {
 			namespace := strings.Split(ns, "/")
 			namespace[3] = "*"
-			mts = append(mts, plugin.MetricType{Namespace_: core.NewNamespace(namespace...)})
+			nss := core.NewNamespace(namespace...)
+			nss[3].Name = "host ID"
+			nss[3].Description = "ID of ES host"
+			mts = append(mts, plugin.MetricType{Namespace_: nss})
 		}
 		break
 	}

--- a/elasticsearch/nodeClient.go
+++ b/elasticsearch/nodeClient.go
@@ -180,7 +180,7 @@ func (esm *ESMetric) setESNodeMetrics() {
 			Namespace_: core.NewNamespace(strings.Split(n, "/")...),
 			Data_:      m,
 			Tags_:      map[string]string{HOST: esm.host},
-			Timestamp_: time.Unix(esm.timestamp, 0),
+			Timestamp_: time.Now(),
 		}
 		mts[n] = dpt
 	}


### PR DESCRIPTION
Summary
* Fixed plugin was not able to load issue due to Snap enforces _*Name*_ to be defined for dynamic element

Test Done
* unit tests
* integration tests
